### PR TITLE
Feature/intel atom

### DIFF
--- a/scripts/numcore.sh
+++ b/scripts/numcore.sh
@@ -12,6 +12,16 @@ if [ "${UKERNEL}" = "Linux" ]; then
   # Linux/x86_64
   if [ "${UMACHINE}" = "x86_64" ]; then
     NUMCORE=$(grep processor /proc/cpuinfo | wc -l)
+
+    # Intel(R) Atom(TM)
+    CPU_MODEL=$(grep "^model name" /proc/cpuinfo |
+      sed 1q | sed 's/^model name.*: //' | awk '{ print $1 " " $2 }')
+
+    if [ "${CPU_MODEL}" = "Intel(R) Atom(TM)" ]; then
+      if [ ${NUM_CORE} -gt 2 ]; then
+        NUM_CORE=2
+      fi
+    fi
   # Linux/armv7l (Raspberry Pi3)
   elif [ "${UMACHINE}" = "armv7l" ]; then
     NUMCORE=2

--- a/scripts/numcore.sh
+++ b/scripts/numcore.sh
@@ -18,8 +18,8 @@ if [ "${UKERNEL}" = "Linux" ]; then
       sed 1q | sed 's/^model name.*: //' | awk '{ print $1 " " $2 }')
 
     if [ "${CPU_MODEL}" = "Intel(R) Atom(TM)" ]; then
-      if [ ${NUM_CORE} -gt 2 ]; then
-        NUM_CORE=2
+      if [ ${NUMCORE} -gt 2 ]; then
+        NUMCORE=2
       fi
     fi
   # Linux/armv7l (Raspberry Pi3)


### PR DESCRIPTION
Support Intel Atom processor
- For Intel Atom processor , even if the number of cores is over 2, it is force set to 2